### PR TITLE
Fixed example code to actually print out the result

### DIFF
--- a/microsoft-r/operationalize/how-to-build-api-clients-from-swagger-for-app-integration.md
+++ b/microsoft-r/operationalize/how-to-build-api-clients-from-swagger-for-app-integration.md
@@ -343,7 +343,7 @@ Build and use a service consumption client library from swagger in CSharp and Ac
    InputParameters inputs = new InputParameters() { Hp = 120, Wt = 2.8 };
    var serviceResult = client.ManualTransmission(inputs);
     
-   Console.Out.WriteLine(serviceResult.OutputParameters);
+   Console.Out.WriteLine(serviceResult.OutputParameters.Answer);
    ```
 
 ## Example in Java


### PR DESCRIPTION
Console.Out.WriteLine(serviceResult.OutputParameters) only print out the class name instead of meaningful value.