### PR TITLE
Update quickstart-publish-r-web-service.md

### DIFF
--- a/microsoft-r/operationalize/quickstart-publish-r-web-service.md
+++ b/microsoft-r/operationalize/quickstart-publish-r-web-service.md
@@ -247,7 +247,7 @@ In this example, we executed these commands to download the Swagger-based JSON f
 
 ```R
 swagger <- api$swagger()
-cat(swagger, file = "swagger.json", append = FALSE) 
+cat(swagger, file = "C:\\temp\\swagger.json", append = FALSE) 
 ``` 
 
 >[!NOTE]


### PR DESCRIPTION
updated code example to use absolute file path to be clear to the reader where the file is being written to and avoid potential file permission issue with relative path.