### PR TITLE
Fixing broken link to Jupyter Notebook documentation

### DIFF
--- a/microsoft-r/python/quickstart-python-tools.md
+++ b/microsoft-r/python/quickstart-python-tools.md
@@ -95,7 +95,7 @@ Jupyter Notebooks is distributed with Anaconda, which is the Python distribution
 For additional instructions on configuring a multi-user server, see [How to add Machine Learning Server modules to single and multi-user Jupyter Notebook instances](how-to-revoscalepy-jupyter-nb-config.md).
 
 > [!Note]
-> Jupyter Notebooks are a presentation concept, integrating script and text on the same page. Script is interactive on the page, often Python or R, but could be any one of the 40 languages supported by Jupyter. The text is user-provided content that describes the script. Notebooks are executed on a server, accessed over http, and rendered as HTML in a browser to the person requesting the notebook. For more information, see [Jupyter documentation](https://jupyter.readthedocs.io/atest/content-quickstart.html).
+> Jupyter Notebooks are a presentation concept, integrating script and text on the same page. Script is interactive on the page, often Python or R, but could be any one of the 40 languages supported by Jupyter. The text is user-provided content that describes the script. Notebooks are executed on a server, accessed over http, and rendered as HTML in a browser to the person requesting the notebook. For more information, see [Jupyter documentation](https://jupyter.readthedocs.io/en/latest/content-quickstart.html).
 
 ### How to load Python samples on Windows
 


### PR DESCRIPTION
Link to Jupyter Notebook was broken - I looked up the new link and replaced it.