### PR TITLE
Fix chapter indexing

### DIFF
--- a/microsoft-r/r/how-to-revoscaler-spark.md
+++ b/microsoft-r/r/how-to-revoscaler-spark.md
@@ -240,7 +240,7 @@ The output shows the summary statistics for *ArrDelay* for each day of the week:
 	 ArrDelay for DayOfWeek=Saturday  Saturday  11.875326 45.24540 -73 1370 83851   
 	 ArrDelay for DayOfWeek=Sunday    Sunday    10.331806 37.33348 -86 1202 93395
 ```
-## 6 - Fit a linear model
+## 7 - Fit a linear model
 
 Use the *rxLinMod* function to fit a linear model using your *airDS* data source. Use a single dependent variable, the factor *DayOfWeek*:
 


### PR DESCRIPTION
Both Summarize data and Fit a linear model are currently indexed as 6, changed the latter to 7.