### PR TITLE
Wrong .cab URL

### DIFF
--- a/microsoft-r/r-client/install-on-windows.md
+++ b/microsoft-r/r-client/install-on-windows.md
@@ -88,7 +88,7 @@ On the machine onto which you are installing, follow this guidance before you be
 
    1. Download Microsoft R Client from https://aka.ms/rclient/.
 
-   1. Download the Microsoft R Open ( *.cab) needed to install R Client from https://go.microsoft.com/fwlink/?LinkId=852724.
+   1. Download the Microsoft R Open ( *.cab) needed to install R Client from https://go.microsoft.com/fwlink/?LinkId=867186.
 
    1. Download .NET Framework 4.5.2 from https://www.microsoft.com/download/details.aspx?id=42642.
 


### PR DESCRIPTION
Url is pointing to outdated version
Wrong : https://go.microsoft.com/fwlink/?LinkId=852724
Correct one : https://go.microsoft.com/fwlink/?LinkId=867186