### PR TITLE
Add the path for RStudio for R Client in Linux

### DIFF
--- a/microsoft-r/r-client/what-is-microsoft-r-client.md
+++ b/microsoft-r/r-client/what-is-microsoft-r-client.md
@@ -69,6 +69,8 @@ While R is a command line driven program, you can also use your favorite R integ
 
 + **Set up RStudio for R Client on Windows or Linux**: [RStudio](https://www.rstudio.com/products/rstudio/download2/) is another popular R IDE. To make R Client the default R engine for RStudio, [update the path to R](https://support.rstudio.com/hc/en-us/articles/200486138-Using-Different-Versions-of-R). For example, point to `C:\Program Files\Microsoft\R Client\R_SERVER\bin\x64` on Windows. 
 
+Similarly, on Linux add "R_LIBS_SITE=/opt/microsoft/rclient/3.4.3/libraries/RServer" on bottom of the file "/opt/microsoft/rclient/3.4.3/runtime/R/etc/Renviron". [Source](https://github.com/rstudio/rstudio/issues/2455#issuecomment-375327109).
+
 After you configure the IDE, a message appears in the console signaling that the Microsoft R Client packages were loaded.
 
 >[!IMPORTANT]


### PR DESCRIPTION
In Linux (Ubuntu), RStudio-Server doesn't detect the R Client by default. 
For the solution, I think the following fix will help who are browsing the documentation.

Add "R_LIBS_SITE=/opt/microsoft/rclient/3.4.3/libraries/RServer" on the path "/opt/microsoft/rclient/3.4.3/runtime/R/etc/Renviron". [Source](https://stackoverflow.com/questions/49365767/cannot-find-revoscaler-in-microsoft-r-client#49431708)