### PR TITLE
Removed whitespace in azurecli add extension command

### DIFF
--- a/microsoft-r/operationalize/configure-run-diagnostics.md
+++ b/microsoft-r/operationalize/configure-run-diagnostics.md
@@ -342,7 +342,7 @@ If you encounter this error, you can re-add the extension as such:
 **Windows:**
 
 ```azurecli
-> az extension add --source 'C:\Program Files\Microsoft\ML Server\Setup\azure_ml_admin_cli-0.0.1-py2.py3-none-any. whl' --yes
+> az extension add --source 'C:\Program Files\Microsoft\ML Server\Setup\azure_ml_admin_cli-0.0.1-py2.py3-none-any.whl' --yes
 ````
 
 **Linux:**


### PR DESCRIPTION
It caused the command to fail when copy-pasting it to the console.