### PR TITLE
Correcting typo + additional clarification

### DIFF
--- a/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
+++ b/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
@@ -46,6 +46,9 @@ The encryption function available in the administration utility relies on the RS
 
      1. On the machine hosting the node, launch a command-line window or terminal  with administrator (Windows) or root/sudo (Linux) privileges.
 
+>[!NOTE]
+> For Machine Learning Server 9.4, use "**az mlserver admin**" instead of "**az ml admin**"
+
      1. Run the command to encrypt:
         ```azurecli
         # With elevated privileges, run the following commands.
@@ -62,7 +65,7 @@ The encryption function available in the administration utility relies on the RS
         
         
         # Encrypt a secret
-        az ml admin credentials set ---cert-store-name <CERT_STORE_NAME> --cert-store-location <CERT_STORE_LOCATION> --cert-subject_name <CERT_SUBJECT_NAME> --secret <secret>
+        az ml admin credentials set --cert-store-name <CERT_STORE_NAME> --cert-store-location <CERT_STORE_LOCATION> --cert-subject_name <CERT_SUBJECT_NAME> --secret <secret>
         ```
         
         |CLI&nbsp;options|Description|

--- a/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
+++ b/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
@@ -46,7 +46,6 @@ The encryption function available in the administration utility relies on the RS
 
      1. On the machine hosting the node, launch a command-line window or terminal  with administrator (Windows) or root/sudo (Linux) privileges.
 
-> For Machine Learning Server 9.4, use "**az mlserver admin**" instead of "**az ml admin**"
 
      1. Run the command to encrypt:
         

--- a/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
+++ b/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
@@ -46,7 +46,6 @@ The encryption function available in the administration utility relies on the RS
 
      1. On the machine hosting the node, launch a command-line window or terminal  with administrator (Windows) or root/sudo (Linux) privileges.
 
-
      1. Run the command to encrypt:
         
         >[!NOTE]

--- a/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
+++ b/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
@@ -50,6 +50,10 @@ The encryption function available in the administration utility relies on the RS
 > For Machine Learning Server 9.4, use "**az mlserver admin**" instead of "**az ml admin**"
 
      1. Run the command to encrypt:
+        
+        >[!NOTE]
+        > For Machine Learning Server 9.4, use "**az mlserver admin**" instead of "**az ml admin**"
+        
         ```azurecli
         # With elevated privileges, run the following commands.
         # Get help on the commands

--- a/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
+++ b/microsoft-r/operationalize/configure-admin-cli-encrypt-credentials.md
@@ -46,7 +46,6 @@ The encryption function available in the administration utility relies on the RS
 
      1. On the machine hosting the node, launch a command-line window or terminal  with administrator (Windows) or root/sudo (Linux) privileges.
 
->[!NOTE]
 > For Machine Learning Server 9.4, use "**az mlserver admin**" instead of "**az ml admin**"
 
      1. Run the command to encrypt:


### PR DESCRIPTION
Correcting typo "---cert-store-name" to "--cert-store-name" 
Added additional clarification, 'az mlserver admin' for 9.4, instead of 'az ml admin'